### PR TITLE
added missing compile and link options to verilator test link cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ set(CXXFLAGS "${SST_CXXFLAGS}")
 set(LDFLAGS "${SST_LDFLAGS}")
 separate_arguments(SST_CXXFLAGS_LIST UNIX_COMMAND ${CXXFLAGS})
 separate_arguments(SST_LDFLAGS_LIST UNIX_COMMAND ${LDFLAGS})
+add_compile_options("${SST_CXXFLAGS_LIST}")
+add_link_options("${SST_LDFLAGS_LIST}")
 
 set(VERILATORSST_EXTERNAL_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/verilator-sst-element")
 

--- a/tests/test_elements/verilator-test-link/CMakeLists.txt
+++ b/tests/test_elements/verilator-test-link/CMakeLists.txt
@@ -21,8 +21,5 @@ target_include_directories(verilatortestlink
                        ${VERILATOR_INCLUDE}
                        ${VERILATOR_INCLUDE}/vltstd)
 
-target_compile_options(verilatortestlink PRIVATE ${SST_CXXFLAGS_LIST})
-target_link_options(verilatortestlink PRIVATE ${SST_LDFLAGS_LIST})
-
 install(TARGETS verilatortestlink DESTINATION ${CMAKE_SOURCE_DIR}/install)
 install(CODE "execute_process(COMMAND sst-register verilatortestlink verilatortestlink_LIBDIR=${CMAKE_SOURCE_DIR}/install)")

--- a/verilator-sst-element/CMakeLists.txt
+++ b/verilator-sst-element/CMakeLists.txt
@@ -189,11 +189,6 @@ target_include_directories(verilatorcomponent
                                  ${VERILATOR_INCLUDE}
                                  ${VERILATOR_INCLUDE}/vltstd)
 
-target_compile_options(verilatorcomponent PRIVATE ${SST_CXXFLAGS_LIST})
-target_link_options(verilatorcomponent PRIVATE ${SST_LDFLAGS_LIST})
-target_compile_options(${targetName} PRIVATE ${SST_CXXFLAGS_LIST})
-target_link_options(${targetName} PRIVATE ${SST_LDFLAGS_LIST})
-
 # -----------------------------------------------------------------
 # Install the source
 # -----------------------------------------------------------------


### PR DESCRIPTION
Fixes missing compile / link options that broke building on macOS ( #21 )